### PR TITLE
added media query for smaller column width at larger resolutions

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,10 @@
+.col-lg-12 {
+    width: 60%;
+};
+
+@media only screen and (max-width: 768px) {
+    /* For mobile phones: */
+    [class*="col-"] {
+      width: 100%;
+    }
+  }

--- a/index.html
+++ b/index.html
@@ -20,19 +20,18 @@
     ></script>
   </head>
   <body>
-    <div class="container">
+    <div class="container text-center">
       <h1>Food Service Log Manager</h1>
       <p>
         <em>Date: <span id="date"></span></em>
       </p>
-      <div class="row mb-3">
+      <div class="row mb-3 justify-content-center">
         <div class="col-lg-12">
           <form id="form">
             <div class="form-group">
-              <label for="sel1">Equipment:</label>
+              <label for="sel1">Equipment ID:</label>
               <select class="form-control" id="selector">
-                <option></option>
-                <!-- This empty value is so that the user must select equipment -->
+                <option value="" selected disabled>Please Select From List</option>
                 <option value="Walk-in Freezer">Walk-in freezer</option>
                 <option value="Cold Storage">Cold Storage</option>
                 <option value="Pastry Station Cooler">
@@ -43,27 +42,26 @@
                 </option>
               </select>
             </div>
-            <div class="row mb-3">
-              <div class="col-lg-12">
-                <label for="name">Name</label>
+                <br>
+                <label for="name">Employee Name:</label>
                 <input
                   name="name"
                   id="userName"
                   type="text"
                   class="form-control"
-                  placeholder="name"
+                  placeholder="Enter Your Name"
                 />
               </div>
             </div>
-            <div class="row mb-3">
+            <div class="row mb-3 justify-content-center">
               <div class="col-lg-12">
-                <label for="temp">Temperature</label>
+                <label for="temp">Temperature:</label>
                 <input
                   name="temp"
                   id="temperature"
                   type="text"
                   class="form-control"
-                  placeholder="°"
+                  placeholder="Enter Temp in °F"
                 />
               </div>
             </div>


### PR DESCRIPTION
Max column width set to 60% when above 768px screen width.  Changes to 100% column width when screen is smaller than 768.

Additionally in this PR:
-Centered the content on Home screen (can easily be reverted if not the look we want)
-Made placeholder text more clear
-Changed initial option in equipment select to be disabled.  Acts as placeholder text and cannot be selected as an option.